### PR TITLE
basic tests using shared fixture suite, improve completeness & parity with JS

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/urfave/cli"
 
-	"github.com/whyrusleeping/ipld-schema/gen-go"
+	gengo "github.com/whyrusleeping/ipld-schema/gen-go"
 	"github.com/whyrusleeping/ipld-schema/parser"
 	"github.com/whyrusleeping/ipld-schema/schema"
 )
@@ -59,7 +59,10 @@ var schemaToJsonCmd = cli.Command{
 			return err
 		}
 
-		out, err := json.MarshalIndent(sc, "", "\t")
+		// JSON schema types should be nested within a "schema" key
+		scm := make(map[string]interface{})
+		scm["schema"] = sc
+		out, err := json.MarshalIndent(scm, "", "\t")
 		if err != nil {
 			panic(err)
 		}

--- a/test/bulk_fixtures_test.go
+++ b/test/bulk_fixtures_test.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+
+	"github.com/whyrusleeping/ipld-schema/parser"
+)
+
+const fixturesDir = "./fixtures/bulk/"
+
+type Fixture struct {
+	Schema          string
+	Expected        string
+	ExpectedParsed  interface{}
+	Blocks          []FixtureBlock
+	BadBlocks       []string `yaml:"badBlocks"`
+	BadBlocksParsed []interface{}
+}
+
+type FixtureBlock struct {
+	Actual         string
+	ActualParsed   interface{}
+	Expected       string
+	ExpectedParsed interface{}
+}
+
+func TestBulk(t *testing.T) {
+	files, err := ioutil.ReadDir(fixturesDir)
+	assert.NoError(t, err)
+
+	for _, f := range files {
+		verifyFixture(t, f.Name())
+	}
+}
+
+func verifyFixture(t *testing.T, name string) {
+	fmt.Printf("verifyFixture(%s)\n", name)
+
+	fx := loadFixture(t, name)
+
+	parsedSchema, err := parser.ParseSchema(bufio.NewScanner(strings.NewReader(fx.Schema)))
+	assert.NoError(t, err)
+
+	actual, err := json.MarshalIndent(parsedSchema, "", "  ")
+	assert.NoError(t, err)
+	expected, err := json.MarshalIndent(fx.ExpectedParsed, "", "  ")
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+
+	/*
+		var out bytes.Buffer
+		err = schema.ExportIpldSchema(parsedSchema, &out)
+		assert.NoError(t, err)
+		regenerated := strings.Replace(strings.Replace(out.String(), "\t", "  ", -1), "\n\n", "\n", -1)
+	*/
+
+	/*
+		fmt.Println("--------- Original Schema:")
+		fmt.Printf(fx.Schema)
+		fmt.Println("--------- Regenerated Schema:")
+		fmt.Printf(regenerated)
+	*/
+
+	/* TODO: order of map[] fields in some structs causes shuffling so we can't do a straight compare
+			 without imposing order retention
+
+	  assert.Equal(t, fx.Schema, regenerated)
+	*/
+}
+
+func loadFixture(t *testing.T, name string) Fixture {
+	file, err := ioutil.ReadFile(fixturesDir + name)
+	assert.NoError(t, err)
+
+	var fx Fixture
+	err = yaml.Unmarshal(file, &fx)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal([]byte(fx.Expected), &fx.ExpectedParsed)
+	assert.NoError(t, err)
+
+	for _, block := range fx.Blocks {
+		err = json.Unmarshal([]byte(block.Actual), &block.ActualParsed)
+		assert.NoError(t, err)
+		err = json.Unmarshal([]byte(block.Expected), &block.ExpectedParsed)
+		assert.NoError(t, err)
+	}
+
+	fx.BadBlocksParsed = make([]interface{}, len(fx.BadBlocks))
+	for i, block := range fx.BadBlocks {
+		err = json.Unmarshal([]byte(block), &(fx.BadBlocksParsed[i]))
+		assert.NoError(t, err)
+	}
+
+	return fx
+}

--- a/test/fixtures/bulk/bytes.yml
+++ b/test/fixtures/bulk/bytes.yml
@@ -1,0 +1,8 @@
+schema: |
+  type SimpleBytes bytes
+expected: |
+  {
+    "SimpleBytes": {
+      "kind": "bytes"
+    }
+  }

--- a/test/fixtures/bulk/enum.yml
+++ b/test/fixtures/bulk/enum.yml
@@ -1,0 +1,43 @@
+schema: |
+  type SimpleEnum enum {
+    | "foo"
+    | "bar"
+    | "baz"
+  }
+expected: |
+  {
+    "SimpleEnum": {
+      "kind": "enum",
+      "members": {
+        "foo": null,
+        "bar": null,
+        "baz": null
+      }
+    }
+  }
+blocks:
+  - actual: |
+      "foo"
+    expected: |
+      "foo"
+  - actual: |
+      "bar"
+    expected: |
+      "bar"
+  - actual: |
+      "baz"
+    expected: |
+      "baz"
+badBlocks:
+  - |
+    "fooz"
+  - |
+    true
+  - |
+    100
+  - |
+    { }
+  - |
+    { "foo": true }
+  - |
+    []

--- a/test/fixtures/bulk/float.yml
+++ b/test/fixtures/bulk/float.yml
@@ -1,0 +1,42 @@
+schema: |
+  type SimpleFloat float
+expected: |
+  {
+    "SimpleFloat": {
+      "kind": "float"
+    }
+  }
+blocks:
+  - actual: |
+      100.1
+    expected: |
+      100.1
+  - actual: |
+      0.1
+    expected: |
+      0.1
+  - actual: |
+      100
+    expected: |
+      100.0
+  - actual: |
+      -1.1
+    expected: |
+      -1.1
+  - actual: |
+      -1
+    expected: |
+      -1
+badBlocks:
+  - |
+    "fooz"
+  - |
+    true
+  - |
+    { }
+  - |
+    { "foo": true }
+  - |
+    []
+  - |
+    [ 100 ]

--- a/test/fixtures/bulk/int.yml
+++ b/test/fixtures/bulk/int.yml
@@ -1,0 +1,36 @@
+schema: |
+  type SimpleInt int
+expected: |
+  {
+    "SimpleInt": {
+      "kind": "int"
+    }
+  }
+blocks:
+  - actual: |
+      100
+    expected: |
+      100
+  - actual: |
+      0
+    expected: |
+      0
+  - actual: |
+      -100
+    expected: |
+      -100
+badBlocks:
+  - |
+    100.1
+  - |
+    "fooz"
+  - |
+    true
+  - |
+    { }
+  - |
+    { "foo": true }
+  - |
+    []
+  - |
+    [ 100 ]

--- a/test/fixtures/bulk/link.yml
+++ b/test/fixtures/bulk/link.yml
@@ -1,0 +1,8 @@
+schema: |
+  type SimpleLink link
+expected: |
+  {
+    "SimpleLink": {
+      "kind": "link"
+    }
+  }

--- a/test/fixtures/bulk/list.yml
+++ b/test/fixtures/bulk/list.yml
@@ -1,0 +1,33 @@
+schema: |
+  type SimpleList [String]
+expected: |
+  {
+    "SimpleList": {
+      "kind": "list",
+      "valueType": "String"
+    }
+  }
+blocks:
+  - actual: |
+      [ "a", "b", "c" ]
+    expected: |
+      [ "a", "b", "c" ]
+  - actual: |
+      [ ]
+    expected: |
+      [ ]
+badBlocks:
+  - |
+    "fooz"
+  - |
+    true
+  - |
+    { }
+  - |
+    { "foo": true }
+  - |
+    [ 100 ]
+  - |
+    [ true ]
+  - |
+    [ {} ]

--- a/test/fixtures/bulk/map-listpairs.yml
+++ b/test/fixtures/bulk/map-listpairs.yml
@@ -1,0 +1,11 @@
+schema: |
+  type MapAsListpairs {String:String} representation listpairs
+expected: |
+  {
+    "MapAsListpairs": {
+      "kind": "map",
+      "keyType": "String",
+      "valueType": "String",
+      "representation": { "listpairs": {} }
+    }
+  }

--- a/test/fixtures/bulk/map-stringpairs.yml
+++ b/test/fixtures/bulk/map-stringpairs.yml
@@ -1,0 +1,19 @@
+schema: |
+  type MapAsStringpairs {String:String} representation stringpairs {
+    innerDelim "="
+    entryDelim ","
+  }
+expected: |
+  {
+    "MapAsStringpairs": {
+      "kind": "map",
+      "keyType": "String",
+      "valueType": "String",
+      "representation": {
+        "stringpairs": {
+          "innerDelim": "=",
+          "entryDelim": ","
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/map-with-nullable.yml
+++ b/test/fixtures/bulk/map-with-nullable.yml
@@ -1,0 +1,11 @@
+schema: |
+  type MapWithNullable {String:nullable String}
+expected: |
+  {
+    "MapWithNullable": {
+      "kind": "map",
+      "keyType": "String",
+      "valueType": "String",
+      "valueNullable": true
+    }
+  }

--- a/test/fixtures/bulk/map.yml
+++ b/test/fixtures/bulk/map.yml
@@ -1,0 +1,34 @@
+schema: |
+  type SimpleMap {String:Int}
+expected: |
+  {
+    "SimpleMap": {
+      "kind": "map",
+      "keyType": "String",
+      "valueType": "Int"
+    }
+  }
+blocks:
+  - actual: |
+      { "a": 1, "b": 2, "c": 100 }
+    expected: |
+      { "a": 1, "b": 2, "c": 100 }
+  - actual: |
+      { }
+    expected: |
+      { }
+badBlocks:
+  - |
+    "fooz"
+  - |
+    true
+  - |
+    [ ]
+  - |
+    { "foo": true }
+  - |
+    { "a": "b" }
+  - |
+    { "a": true }
+
+# TODO: maps without string keys .. how to do in yaml?

--- a/test/fixtures/bulk/struct-listpairs.yml
+++ b/test/fixtures/bulk/struct-listpairs.yml
@@ -1,0 +1,24 @@
+schema: |
+  type StructAsListpairs struct {
+    foo Int
+    bar Bool
+    baz String
+  } representation listpairs
+expected: |
+  {
+    "StructAsListpairs": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": { "listpairs": {} }
+    }
+  }

--- a/test/fixtures/bulk/struct-map-with-implicits.yml
+++ b/test/fixtures/bulk/struct-map-with-implicits.yml
@@ -1,0 +1,36 @@
+schema: |
+  type StructAsMapWithImplicits struct {
+    bar Bool (implicit "false")
+    boom String (implicit "yay")
+    baz String
+    foo Int (implicit "0")
+  }
+expected: |
+  {
+    "StructAsMapWithImplicits": {
+      "kind": "struct",
+      "fields": {
+        "bar": {
+          "type": "Bool"
+        },
+        "boom": {
+          "type": "String"
+        },
+        "baz": {
+          "type": "String"
+        },
+        "foo": {
+          "type": "Int"
+        }
+      },
+      "representation": {
+        "map": {
+          "fields": {
+            "bar": { "implicit": false },
+            "boom": { "implicit": "yay" },
+            "foo": { "implicit": 0 }
+          }
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-map-with-renames.yml
+++ b/test/fixtures/bulk/struct-map-with-renames.yml
@@ -1,0 +1,39 @@
+schema: |
+  type StructAsMapWithRenames struct {
+    bar Bool (rename "b")
+    boom String
+    baz String (rename "z")
+    foo Int (implicit "0" rename "f")
+  }
+expected: |
+  {
+    "StructAsMapWithRenames": {
+      "kind": "struct",
+      "fields": {
+        "bar": {
+          "type": "Bool"
+        },
+        "boom": {
+          "type": "String"
+        },
+        "baz": {
+          "type": "String"
+        },
+        "foo": {
+          "type": "Int"
+        }
+      },
+      "representation": {
+        "map": {
+          "fields": {
+            "bar": { "rename": "b" },
+            "baz": { "rename": "z" },
+            "foo": {
+              "implicit": 0,
+              "rename": "f"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-stringjoin-custom-fieldorder.yml
+++ b/test/fixtures/bulk/struct-stringjoin-custom-fieldorder.yml
@@ -1,0 +1,36 @@
+schema: |
+  type StructAsStringjoin struct {
+    foo Int
+    bar Bool
+    baz String
+  } representation stringjoin {
+    join ":"
+    fieldOrder ["baz", "bar", "foo"]
+  }
+expected: |
+  {
+    "StructAsStringjoin": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "stringjoin": {
+          "fieldOrder": [
+            "baz",
+            "bar",
+            "foo"
+          ],
+          "join": ":"
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-stringjoin.yml
+++ b/test/fixtures/bulk/struct-stringjoin.yml
@@ -1,0 +1,28 @@
+schema: |
+  type StructAsStringjoin struct {
+    foo Int
+    bar Bool
+    baz String
+  } representation stringjoin {
+    join ":"
+  }
+expected: |
+  {
+    "StructAsStringjoin": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "stringjoin": { "join": ":" }
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-stringpairs.yml
+++ b/test/fixtures/bulk/struct-stringpairs.yml
@@ -1,0 +1,32 @@
+schema: |
+  type StructAsStringpairs struct {
+    foo Int
+    bar Bool
+    baz String
+  } representation stringpairs {
+    innerDelim "="
+    entryDelim ","
+  }
+expected: |
+  {
+    "StructAsStringpairs": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "stringpairs": {
+          "innerDelim": "=",
+          "entryDelim": ","
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-tuple-custom-fieldorder.yml
+++ b/test/fixtures/bulk/struct-tuple-custom-fieldorder.yml
@@ -1,0 +1,34 @@
+schema: |
+  type StructAsTupleWithCustomFieldorder struct {
+    foo Int
+    bar Bool
+    baz String
+  } representation tuple {
+    fieldOrder ["baz", "bar", "foo"]
+  }
+expected: |
+  {
+    "StructAsTupleWithCustomFieldorder": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "tuple": {
+          "fieldOrder": [
+            "baz",
+            "bar",
+            "foo"
+          ]
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-tuple.yml
+++ b/test/fixtures/bulk/struct-tuple.yml
@@ -1,0 +1,27 @@
+
+schema: |
+  type StructTuple struct {
+    foo Int
+    bar Bool
+    baz String
+  } representation tuple
+expected: |
+  {
+    "StructTuple": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "tuple": {}
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-with-anonymous-types.yml
+++ b/test/fixtures/bulk/struct-with-anonymous-types.yml
@@ -1,0 +1,53 @@
+schema: |
+  type StructWithAnonymousTypes struct {
+    fooField optional {String:String}
+    barField nullable {String:String}
+    bazField {String:nullable String}
+    wozField {String:[nullable String]}
+  }
+expected: |
+  {
+    "StructWithAnonymousTypes": {
+      "kind": "struct",
+      "fields": {
+        "fooField": {
+          "type": {
+            "kind": "map",
+            "keyType": "String",
+            "valueType": "String"
+          },
+          "optional": true
+        },
+        "barField": {
+          "type": {
+            "kind": "map",
+            "keyType": "String",
+            "valueType": "String"
+          },
+          "nullable": true
+        },
+        "bazField": {
+          "type": {
+            "kind": "map",
+            "keyType": "String",
+            "valueType": "String",
+            "valueNullable": true
+          }
+        },
+        "wozField": {
+          "type": {
+            "kind": "map",
+            "keyType": "String",
+            "valueType": {
+              "kind": "list",
+              "valueType": "String",
+              "valueNullable": true
+            }
+          }
+        }
+      },
+      "representation": {
+        "map": {}
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct.yml
+++ b/test/fixtures/bulk/struct.yml
@@ -1,0 +1,93 @@
+schema: |
+  type SimpleStruct struct {
+    foo Int
+    bar Bool
+    baz String
+  }
+expected: |
+  {
+    "SimpleStruct": {
+      "kind": "struct",
+      "fields": {
+        "foo": {
+          "type": "Int"
+        },
+        "bar": {
+          "type": "Bool"
+        },
+        "baz": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "map": {}
+      }
+    }
+  }
+blocks:
+  - actual: |
+      {
+        "foo": 100,
+        "bar": true,
+        "baz": "this is baz yo"
+      }
+    expected: |
+      {
+        "foo": 100,
+        "bar": true,
+        "baz": "this is baz yo"
+      }
+  - actual: # is this OK? string-to-int
+      |
+      {
+        "foo": "100",
+        "bar": true,
+        "baz": "this is baz yo"
+      }
+    expected: |
+      {
+        "foo": 100,
+        "bar": true,
+        "baz": "this is baz yo"
+      }
+  - actual: # is this OK? float-to-int
+      |
+      {
+        "foo": 100.0,
+        "bar": true,
+        "baz": "this is baz yo"
+      }
+    expected: |
+      {
+        "foo": 100,
+        "bar": true,
+        "baz": "this is baz yo"
+      }
+badBlocks:
+  - |
+    {
+      "foo": 100
+    }
+  - |
+    {
+      "foo": 100,
+      "bar": true
+    }
+  - |
+    {
+      "foo": "str",
+      "bar": true,
+      "baz": "this is baz yo"
+    }
+  - |
+    {
+      "foo": 100,
+      "bar": 100,
+      "baz": "this is baz yo"
+    }
+  - |
+    {
+      "foo": 100,
+      "bar": true,
+      "baz": false
+    }

--- a/test/fixtures/bulk/union-envelope.yml
+++ b/test/fixtures/bulk/union-envelope.yml
@@ -1,0 +1,75 @@
+schema: |
+  type Bar bool
+  type Baz string
+  type Foo int
+  type UnionEnvelope union {
+    | Foo "foo"
+    | Bar "bar"
+    | Baz "baz"
+  } representation envelope {
+    discriminantKey "bim"
+    contentKey "bam"
+  }
+root: UnionEnvelope
+expected: |
+  {
+    "Bar": {
+      "kind": "bool"
+    },
+    "Baz": {
+      "kind": "string"
+    },
+    "Foo": {
+      "kind": "int"
+    },
+    "UnionEnvelope": {
+      "kind": "union",
+      "representation": {
+        "envelope": {
+          "discriminantKey": "bim",
+          "contentKey": "bam",
+          "discriminantTable": {
+            "foo": "Foo",
+            "bar": "Bar",
+            "baz": "Baz"
+          }
+        }
+      }
+    }
+  }
+blocks:
+  - actual: |
+      { "bim": "foo", "bam": 100 }
+    expected: |
+      100
+  - actual: |
+      { "bim": "bar", "bam": true }
+    expected: |
+      true
+  - actual: |
+      { "bim": "baz", "bam": "here be baz" }
+    expected: |
+      "here be baz"
+badBlocks:
+  - |
+    { "bim": "foo" }
+  - |
+    { "bim": "bar" }
+  - |
+    { "bim": "baz" }
+  - |
+    { "bim": "foo", "bam": "zot" }
+  - |
+    { "bim": "bar", "bam": 100 }
+  - |
+    { "bim": "baz", "bam": true }
+  - |
+    100
+  - |
+    true
+  - |
+    "here be string"
+  - |
+    { }
+  - |
+    [ ]

--- a/test/fixtures/bulk/union-inline.yml
+++ b/test/fixtures/bulk/union-inline.yml
@@ -1,0 +1,80 @@
+schema: |
+  type Bar struct {
+    bral String
+  }
+  type Foo struct {
+    froz Bool
+  }
+  type UnionInline union {
+    | Foo "foo"
+    | Bar "bar"
+  } representation inline {
+    discriminantKey "tag"
+  }
+root: UnionInline
+expected: |
+  {
+    "UnionInline": {
+      "kind": "union",
+      "representation": {
+        "inline": {
+          "discriminantKey": "tag",
+          "discriminantTable": {
+            "foo": "Foo",
+            "bar": "Bar"
+          }
+        }
+      }
+    },
+    "Foo": {
+      "kind": "struct",
+      "fields": {
+        "froz": {
+          "type": "Bool"
+        }
+      },
+      "representation": {
+        "map": {}
+      }
+    },
+    "Bar": {
+      "kind": "struct",
+      "fields": {
+        "bral": {
+          "type": "String"
+        }
+      },
+      "representation": {
+        "map": {}
+      }
+    }
+  }
+blocks:
+  - actual: |
+      { "tag": "foo", "froz": true }
+    expected: |
+      { "froz": true }
+  - actual: |
+      { "tag": "bar", "bral": "zot" }
+    expected: |
+      { "bral": "zot" }
+badBlocks:
+  - |
+    { "froz": true }
+  - |
+    { "bral": "zot" }
+  - |
+    { "tag": "foo" }
+  - |
+    { "tag": "bar" }
+  - |
+    { "tag": "foo", "bral": "zot" }
+  - |
+    { "tag": "bar", "froz": true }
+  - |
+    { "tag": "foo", "froz": "zot" }
+  - |
+    { "tag": "bar", "bral": true }
+  - |
+    { }
+

--- a/test/fixtures/bulk/union-keyed.yml
+++ b/test/fixtures/bulk/union-keyed.yml
@@ -1,0 +1,42 @@
+schema: |
+  type UnionKeyed union {
+    | Bool "bar"
+    | Int "foo"
+    | String "baz"
+  } representation keyed
+expected: |
+  {
+    "UnionKeyed": {
+      "kind": "union",
+      "representation": {
+        "keyed": {
+          "bar": "Bool",
+          "foo": "Int",
+          "baz": "String"
+        }
+      }
+    }
+  }
+blocks:
+  - actual: |
+      { "foo": 100 }
+    expected: |
+      { "foo": 100 }
+  - actual: |
+      { "bar": true }
+    expected: |
+      { "bar": true }
+  - actual: |
+      { "baz": "this here is baz" }
+    expected: |
+      { "baz": "this here is baz" }
+badBlocks:
+  - |
+    { "foo": "not an int" }
+  - |
+    { "bar": "not a boolean" }
+  - |
+    { "baz": true }
+  - |
+    { }
+

--- a/test/fixtures/bulk/union-kinded.yml
+++ b/test/fixtures/bulk/union-kinded.yml
@@ -1,0 +1,58 @@
+schema: |
+  type Bar bool
+  type Baz string
+  type Foo int
+  type UnionKinded union {
+    | Foo int
+    | Bar bool
+    | Baz string
+  } representation kinded
+root: UnionKinded
+expected: |
+  {
+    "Bar": {
+      "kind": "bool"
+    },
+    "Baz": {
+      "kind": "string"
+    },
+    "Foo": {
+      "kind": "int"
+    },
+    "UnionKinded": {
+      "kind": "union",
+      "representation": {
+        "kinded": {
+          "int": "Foo",
+          "bool": "Bar",
+          "string": "Baz"
+        }
+      }
+    }
+  }
+blocks:
+  - actual: |
+      100
+    expected: |
+      100
+  - actual: |
+      true
+    expected: |
+      true
+  - actual: |
+      "this here is baz"
+    expected: |
+      "this here is baz"
+badBlocks:
+  - |
+    100.1
+  - |
+    { "foo": 100 }
+  - |
+    { "bar": true }
+  - |
+    { "baz": "don't match" }
+  - |
+    { }
+  - |
+    [ 1, 2, 3 ]

--- a/test/fixtures/hashmap/hashmap.ipldsch
+++ b/test/fixtures/hashmap/hashmap.ipldsch
@@ -1,0 +1,50 @@
+# https://github.com/ipld/specs/blob/01f19b1f4234a9528c618756b7e9c24b4d499b7c/schema-layer/data-structures/hashmap.md
+
+#
+# type HashMap map { Key : Value } representation HashMap
+#
+# advanced HashMap {
+#   kind map
+#   implementation "IPLD/HAMT/1"
+#   rootType HashMapRoot
+# }
+#
+
+# Root node layout
+type HashMapRoot struct {
+  hashAlg String
+  bitWidth Int
+  bucketSize Int
+  map Bytes
+  data [ Element ]
+}
+
+# Non-root node layout
+type HashMapNode struct {
+  map Bytes
+  data [ Element ]
+}
+
+type Element union {
+  | HashMapNode map
+  | &HashMapNode link
+  | Bucket list
+} representation kinded
+
+type Bucket list [ BucketEntry ]
+
+type BucketEntry struct {
+  key Bytes
+  value Value (implicit "null")
+} representation tuple
+
+type Value union {
+  | Bool bool
+  | String string
+  | Bytes bytes
+  | Int int
+  | Float float
+  | Map map
+  | List list
+  | Link link
+} representation kinded

--- a/test/fixtures/schema-schema.ipldsch
+++ b/test/fixtures/schema-schema.ipldsch
@@ -8,7 +8,8 @@
 ## There are some additional rules that should be applied:
 ##   - Type names should by convention begin with a capital letter;
 ##   - Type names must be all printable characters (no whitespace);
-##   - Type names must not contain punctuation (dashes, dots, etc).
+##   - Type names must not contain punctuation other than underscores
+##     (dashes, dots, etc.).
 ##
 ## Type names are strings meant for human consumption at a local scope.
 ## When making a Schema, note that the TypeName is the key of the map:
@@ -54,9 +55,9 @@ type Schema union {
 ##
 ## The Type union is serialized using "inline" union representation,
 ## which means all of its members have map representations, and there will be
-## an entry in that map called "type" which contains the union discriminator.
+## an entry in that map called "type" which contains the union discriminant.
 ##
-## Some of the kinds of type are so simple the union discriminator is the only
+## Some of the kinds of type are so simple the union discriminant is the only
 ## content at all, e.g. strings:
 ##
 ## ```
@@ -135,6 +136,18 @@ type RepresentationKind enum {
 	| "link"
 }
 
+## AnyScalar defines a union of the basic non-complex kinds.
+##
+## Useful defining usage of IPLD nodes that do compose from other nodes.
+##
+type AnyScalar union {
+	| Bool bool
+	| String string
+	| Bytes bytes
+	| Int int
+	| Float float
+} representation kinded
+
 ## TypeBool describes a simple boolean type.
 ## It has no details.
 ##
@@ -167,7 +180,56 @@ type TypeMap struct {
 	keyType TypeName # additionally, the referenced type must be reprkind==string.
 	valueType TypeTerm
 	valueNullable Bool (implicit "false")
+	representation MapRepresentation
 } representation map
+
+## MapRepresentation describes how a map type should be mapped onto
+## its IPLD Data Model representation.  By default a map is a map in the
+## Data Model but other kinds can be configured.
+##
+type MapRepresentation union {
+	| MapRepresentation_Map "map"
+	| MapRepresentation_StringPairs "stringpairs"
+	| MapRepresentation_ListPairs "listpairs"
+} representation keyed
+
+## MapRepresentation_Map describes that a map should be encoded as
+## a map in the Data Model
+##
+type MapRepresentation_Map struct {}
+
+## MapRepresentation_StringPairs describes that a map should be encoded as a
+## string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## The separating delimiter may be specified with "entryDelim", and the k/v
+## delimiter may be specified with "innerDelim". So a "k=v" naive
+## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+## of ",".
+##
+## This serial representation is limited: the domain of keys must
+## exclude the "innerDelim" and values and keys must exclude ",".
+## There is no facility for escaping, such as in escaped CSV.
+## This also leads to a further restriction that this representation is only
+## valid for maps whose keys and values may all be encoded to string form
+## without conflicts in delimiter character. It is recommended, therefore,
+## that its use be limited to maps containing values with the basic data
+## model kinds that exclude multiple values (i.e. no maps, lists, and therefore
+## structs or unions).
+##
+type MapRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+
+## MapRepresentation_ListPairs describes that a map should be encoded as a
+## list in the IPLD Data Model. This list comprises a sub-list for each entry,
+## in the form: [[k1,v1],[k2,v2]].
+##
+## This representation type is similar to StructRepresentation_Tuple except
+## it includes the keys. This is critical for maps since the keys are not
+## defined in the schema (hence "tuple" representation isn't available for
+## maps).
+##
+type MapRepresentation_ListPairs struct {}
 
 ## TypeList describes a list.
 ## The values of the list have some specific type of their own.
@@ -179,10 +241,25 @@ type TypeList struct {
 
 ## TypeLink describes a hash linking to another object (a CID).
 ##
-## REVIEW: this currently has no details... but possibly it should have a
-## type hint for what we expect when resolving the link?
+## A link also has an "expectedType" that provides a hinting mechanism
+## suggesting what we should find if we were to follow the link. This
+## cannot be strictly enforced by a node or block-level schema
+## validation but may be enforced elsewhere in an application relying on
+## a schema.
 ##
-type TypeLink struct {}
+## The expectedType is specified with the `&Any` link shorthand, where
+## `Any` may be replaced with a specific type.
+##
+## Unlike other kinds, we use `&Type` to denote a link Type rather than
+## `Link`. In this usage, we replace `Type` the expected Type, with `&Any`
+## being shorthand for "a link which may resolve to a type of any kind".
+##
+## `expectedType` is a String, but it should validate as "Any" or a TypeName
+## found somewhere in the schema.
+##
+type TypeLink struct {
+	expectedType String (implicit "Any")
+}
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
 ## more verbosely, a "discriminated union").
@@ -239,12 +316,12 @@ type UnionRepresentation_Keyed {String:TypeName}
 
 ## "Envelope" union representations will encode as a map, where the map has
 ## exactly two entries: the two keys should be of the exact strings specified
-## for this envelope representation.  The value for the discriminator key
+## for this envelope representation.  The value for the discriminant key
 ## should be one of the strings in the discriminant table.  The value for
 ## the content key should be the content, and be of the Type matching the
 ## lookup in the discriminant table.
 type UnionRepresentation_Envelope struct {
-	discriminatorKey String
+	discriminantKey String
 	contentKey String
 	discriminantTable {String:TypeName}
 }
@@ -257,16 +334,16 @@ type UnionRepresentation_Envelope struct {
 ## All members of an inline union must be struct types and must encode to
 ## the map RepresentationKind.  Other types which encode to map (such as map
 ## types themselves!) cannot be used: the potential for content values with
-## with keys overlapping with the discriminatorKey would result in undefined
+## with keys overlapping with the discriminantKey would result in undefined
 ## behavior!  Similarly, the member struct types may not have fields which
-## have names that collide with the discriminatorKey.
+## have names that collide with the discriminantKey.
 ##
 ## When designing a new protocol, use inline unions sparringly; despite
 ## appearing simple, they have the most edge cases of any kind of union
 ## representation, and their implementation is generally the most complex and
 ## is difficult to optimize deserialization to support.
 type UnionRepresentation_Inline struct {
-	discriminatorKey String
+	discriminantKey String
 	discriminantTable {String:TypeName}
 }
 
@@ -280,9 +357,23 @@ type UnionRepresentation_Inline struct {
 ## also exist).
 ##
 type TypeStruct struct {
-	fields {String:StructField}
+	fields {FieldName:StructField}
 	representation StructRepresentation
 }
+
+## FieldName is an alias of string.
+##
+## There are some additional rules that should be applied:
+##   - Field names should by convention begin with a lower-case letter;
+##   - Field names must be all printable characters (no whitespace);
+##   - Field names must not contain punctuation other than underscores
+##     (dashes, dots, etc.).
+##
+## Field names are strings meant for human consumption at a local scope.
+## When making a Schema, note that the FieldName is the key of the map:
+## a FieldName must be unique within the Schema.
+##
+type FieldName string
 
 ## StructField describes the properties of each field declared by a TypeStruct.
 ##
@@ -303,13 +394,14 @@ type TypeStruct struct {
 ## Note that the 'optional' and 'nullable' properties are not themselves
 ## optional... however, in the IPLD serial representation of schemas, you'll
 ## often see them absent from the map encoding a StructField.  This is because
-## these fields are specified to have a *default* of false.
-## Defaults in a map representation of a struct mean that those entries may
+## these fields are specified to be implicitly false.
+## Implicits in a map representation of a struct mean that those entries may
 ## be missing from the map encoding... but unlike with "optional" fields, there
-## is no "undefined" value; absense is simply interpreted as the default.
-## (With default fields, an explicitly encoded default value is actually an
+## is no "undefined" value; absence is simply interpreted as the value specified
+## as the implicit.
+## (With implicit fields, an explicitly encoded implicit value is actually an
 ## error instead!)  "Optional" fields give rise to N+1 cardinality logic,
-## just like "nullable" fields; "default" fields *do not*.
+## just like "nullable" fields; "implicit" fields *do not*.
 ##
 type StructField struct {
 	type TypeTerm
@@ -358,41 +450,52 @@ type InlineDefn union {
 ## StructRepresentation describes how a struct type should be mapped onto
 ## its IPLD Data Model representation.  Typically, maps are the representation
 ## kind, but other kinds and details can be configured.
+##
 type StructRepresentation union {
 	| StructRepresentation_Map "map"
 	| StructRepresentation_Tuple "tuple"
+	| StructRepresentation_StringPairs "stringpairs"
+	| StructRepresentation_StringJoin "stringjoin"
+	| StructRepresentation_ListPairs "listpairs"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
-## representation.  For example, fields may be aliased,
-## or default values associated.
+## representation. Field serialization options may optionally be configured to
+## enable mapping serialized keys using the 'rename' option, or implicit values
+## specified where the field is omitted from the serialized form using the
+## 'implicit' option.
+##
+## See StructRepresentation_Map_FieldDetails for details on the 'rename' and
+## 'implicit' options.
+##
 type StructRepresentation_Map struct {
-	fields optional {String:StructRepresentation_Map_FieldDetails}
+	fields optional {FieldName:StructRepresentation_Map_FieldDetails}
 }
+
 ## StructRepresentation_Map_FieldDetails describes additional properties of a
-## struct field when represented as a map.  For example, fields may be aliased,
-## or default values associated.
+## struct field when represented as a map.  For example, fields may be renamed,
+## or implicit values associated.
 ##
-## If a default value is defined, then during marshalling, if the actual value
-## is the default value, that field will be omitted from the map; and during
-## unmarshalling, correspondingly, the absense of that field will be interpreted
-## as being the default value.
+## If an implicit value is defined, then during marshalling, if the actual value
+## is the implicit value, that field will be omitted from the map; and during
+## unmarshalling, correspondingly, the absence of that field will be interpreted
+## as being the implicit value.
 ##
-## Note that fields with defaults are distinct from fields which are optional!
+## Note that fields with implicits are distinct from fields which are optional!
 ## The cardinality of membership of an optional field is is incremented:
 ## e.g., the cardinality of "fieldname Bool" is 2; "fieldname optional Bool" is
 ## membership cardinality *3*, because it may also be undefined.
-## By contrast, the cardinality of membership of a field with a default value
+## By contrast, the cardinality of membership of a field with an implicit value
 ## remains unchanged; there is serial state which can map to an undefined value.
 ##
-## Note that 'alias' supports exactly one string, and not a list: this is
-## intentional.  The alias feature is meant to allow serial representations
+## Note that 'rename' supports exactly one string, and not a list: this is
+## intentional.  The rename feature is meant to allow serial representations
 ## to use a different key string than the schema type definition field name;
-## it is not intented to be used for migration purposes.
+## it is not intended to be used for migration purposes.
 ##
 type StructRepresentation_Map_FieldDetails struct {
-	alias optional String
-	default optional Any # Review: may be better to introduce a small kinded union here which has the essential scalars as members.
+	rename optional String
+	implicit optional AnyScalar
 }
 
 ## StructRepresentation_Tuple describes a way to map a struct type into a list
@@ -400,13 +503,62 @@ type StructRepresentation_Map_FieldDetails struct {
 ##
 ## Tuple representations are less flexible than map representations:
 ## field order can be specified in order to override the order defined
-## in the type, but optionals and defaults are not (currently) supported.
+## in the type, but optionals and implicits are not (currently) supported.
+## A `fieldOrder` list must include quoted strings (FieldName is a string
+## type) which are coerced to the names of the struct fields. e.g.:
+##   fieldOrder ["Foo", "Bar", "Baz"]
+##
 type StructRepresentation_Tuple struct {
-	fieldOrder optional [String]
+	fieldOrder optional [FieldName]
 }
+
+## StructRepresentation_StringPairs describes that a struct should be encoded
+## as a string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## The separating delimiter may be specified with "entryDelim", and the k/v
+## delimiter may be specified with "innerDelim". So a "k=v" naive
+## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+## of ",".
+##
+## Serialization a struct with stringpairs works the same way as serializing
+## a map with stringpairs and the same character limitations exist. See
+## MapRepresentation_StringPairs for more details on these limitations.
+##
+type StructRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+
+## StructRepresentation_StringJoin describes a way to encode a struct to
+## a string in the IPLD Data Model. Similar to tuple representation, the
+## keys are dropped as they may be inferred from the struct definition.
+## values are concatenated, in order, and separated by a "join" delimiter.
+## For example, specifying ":" as the "join": "v1,v2,v3".
+##
+## stringjoin is necessarily restrictive and therefore only valid for structs
+## whose values may all be encoded to string form without conflicts in "join"
+## character. It is recommended, therefore, that its use be limited to structs
+## containing values with the basic data model kinds that exclude multiple
+## values (i.e. no maps, lists, and therefore structs or unions).
+##
+type StructRepresentation_StringJoin struct {
+	join String
+	fieldOrder optional [FieldName]
+}
+
+## StructRepresentation_ListPairs describes that a struct, should be encoded as
+## a list in the IPLD Data Model. This list comprises a sub-list for each
+## entry, in the form: [[k1,v1],[k2,v2]].
+##
+## This representation type encodes in the same way as
+## MapStructRepresentation_Tuple. It is also similar to
+## StructRepresentation_Tuple except it includes the keys in nested lists.
+## A tuple representation for a struct will encode more compact than listpairs.
+##
+type StructRepresentation_ListPairs struct {}
 
 ## TypeEnum describes a type which has a known, pre-defined set of possible
 ## values.  Each of the values must be representable a string.
+##
 type TypeEnum struct {
 	members {String:Null}
 }

--- a/test/fixtures/schema-schema.ipldsch.json
+++ b/test/fixtures/schema-schema.ipldsch.json
@@ -1,0 +1,470 @@
+{
+	"schema": {
+		"TypeName": {
+			"kind": "string"
+		},
+		"SchemaMap": {
+			"kind": "map",
+			"keyType": "TypeName",
+			"valueType": "Type"
+		},
+		"Schema": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"schema": "SchemaMap"
+				}
+			}
+		},
+		"Type": {
+			"kind": "union",
+			"representation": {
+				"inline": {
+					"discriminantKey": "kind",
+					"discriminantTable": {
+						"bool": "TypeBool",
+						"string": "TypeString",
+						"bytes": "TypeBytes",
+						"int": "TypeInt",
+						"float": "TypeFloat",
+						"map": "TypeMap",
+						"list": "TypeList",
+						"link": "TypeLink",
+						"union": "TypeUnion",
+						"struct": "TypeStruct",
+						"enum": "TypeEnum"
+					}
+				}
+			}
+		},
+		"TypeKind": {
+			"kind": "enum",
+			"members": {
+				"bool": null,
+				"string": null,
+				"bytes": null,
+				"int": null,
+				"float": null,
+				"map": null,
+				"list": null,
+				"link": null,
+				"union": null,
+				"struct": null,
+				"enum": null
+			}
+		},
+		"RepresentationKind": {
+			"kind": "enum",
+			"members": {
+				"bool": null,
+				"string": null,
+				"bytes": null,
+				"int": null,
+				"float": null,
+				"map": null,
+				"list": null,
+				"link": null
+			}
+		},
+		"AnyScalar": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"bool": "Bool",
+					"string": "String",
+					"bytes": "Bytes",
+					"int": "Int",
+					"float": "Float"
+				}
+			}
+		},
+		"TypeBool": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeString": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeBytes": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeInt": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeFloat": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeMap": {
+			"kind": "struct",
+			"fields": {
+				"keyType": {
+					"type": "TypeName"
+				},
+				"valueType": {
+					"type": "TypeTerm"
+				},
+				"valueNullable": {
+					"type": "Bool"
+				},
+				"representation": {
+					"type": "MapRepresentation"
+				}
+			},
+			"representation": {
+				"map": {
+					"fields": {
+						"valueNullable": {
+							"implicit": false
+						}
+					}
+				}
+			}
+		},
+		"MapRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"map": "MapRepresentation_Map",
+					"stringpairs": "MapRepresentation_StringPairs",
+					"listpairs": "MapRepresentation_ListPairs"
+				}
+			}
+		},
+		"MapRepresentation_Map": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"MapRepresentation_StringPairs": {
+			"kind": "struct",
+			"fields": {
+				"innerDelim": {
+					"type": "String"
+				},
+				"entryDelim": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"MapRepresentation_ListPairs": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeList": {
+			"kind": "struct",
+			"fields": {
+				"valueType": {
+					"type": "TypeTerm"
+				},
+				"valueNullable": {
+					"type": "Bool"
+				}
+			},
+			"representation": {
+				"map": {
+					"fields": {
+						"valueNullable": {
+							"implicit": false
+						}
+					}
+				}
+			}
+		},
+		"TypeLink": {
+			"kind": "struct",
+			"fields": {
+				"expectedType": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {
+					"fields": {
+						"expectedType": {
+							"implicit": "Any"
+						}
+					}
+				}
+			}
+		},
+		"TypeUnion": {
+			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "UnionRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"UnionRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"kinded": "UnionRepresentation_Kinded",
+					"keyed": "UnionRepresentation_Keyed",
+					"envelope": "UnionRepresentation_Envelope",
+					"inline": "UnionRepresentation_Inline"
+				}
+			}
+		},
+		"UnionRepresentation_Kinded": {
+			"kind": "map",
+			"keyType": "RepresentationKind",
+			"valueType": "TypeName"
+		},
+		"UnionRepresentation_Keyed": {
+			"kind": "map",
+			"keyType": "String",
+			"valueType": "TypeName"
+		},
+		"UnionRepresentation_Envelope": {
+			"kind": "struct",
+			"fields": {
+				"discriminantKey": {
+					"type": "String"
+				},
+				"contentKey": {
+					"type": "String"
+				},
+				"discriminantTable": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "TypeName"
+					}
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"UnionRepresentation_Inline": {
+			"kind": "struct",
+			"fields": {
+				"discriminantKey": {
+					"type": "String"
+				},
+				"discriminantTable": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "TypeName"
+					}
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeStruct": {
+			"kind": "struct",
+			"fields": {
+				"fields": {
+					"type": {
+						"kind": "map",
+						"keyType": "FieldName",
+						"valueType": "StructField"
+					}
+				},
+				"representation": {
+					"type": "StructRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"FieldName": {
+			"kind": "string"
+		},
+		"StructField": {
+			"kind": "struct",
+			"fields": {
+				"type": {
+					"type": "TypeTerm"
+				},
+				"optional": {
+					"type": "Bool"
+				},
+				"nullable": {
+					"type": "Bool"
+				}
+			},
+			"representation": {
+				"map": {
+					"fields": {
+						"optional": {
+							"implicit": false
+						},
+						"nullable": {
+							"implicit": false
+						}
+					}
+				}
+			}
+		},
+		"TypeTerm": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"string": "TypeName",
+					"map": "InlineDefn"
+				}
+			}
+		},
+		"InlineDefn": {
+			"kind": "union",
+			"representation": {
+				"inline": {
+					"discriminantKey": "kind",
+					"discriminantTable": {
+						"map": "TypeMap",
+						"list": "TypeList"
+					}
+				}
+			}
+		},
+		"StructRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"map": "StructRepresentation_Map",
+					"tuple": "StructRepresentation_Tuple",
+					"stringpairs": "StructRepresentation_StringPairs",
+					"stringjoin": "StructRepresentation_StringJoin",
+					"listpairs": "StructRepresentation_ListPairs"
+				}
+			}
+		},
+		"StructRepresentation_Map": {
+			"kind": "struct",
+			"fields": {
+				"fields": {
+					"type": {
+						"kind": "map",
+						"keyType": "FieldName",
+						"valueType": "StructRepresentation_Map_FieldDetails"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_Map_FieldDetails": {
+			"kind": "struct",
+			"fields": {
+				"rename": {
+					"type": "String",
+					"optional": true
+				},
+				"implicit": {
+					"type": "AnyScalar",
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_Tuple": {
+			"kind": "struct",
+			"fields": {
+				"fieldOrder": {
+					"type": {
+						"kind": "list",
+						"valueType": "FieldName"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_StringPairs": {
+			"kind": "struct",
+			"fields": {
+				"innerDelim": {
+					"type": "String"
+				},
+				"entryDelim": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_StringJoin": {
+			"kind": "struct",
+			"fields": {
+				"join": {
+					"type": "String"
+				},
+				"fieldOrder": {
+					"type": {
+						"kind": "list",
+						"valueType": "FieldName"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_ListPairs": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeEnum": {
+			"kind": "struct",
+			"fields": {
+				"members": {
+					"type": {
+						"kind": "map",
+						"keyType": "String",
+						"valueType": "Null"
+					}
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		}
+	}
+}

--- a/test/schema_schema_test.go
+++ b/test/schema_schema_test.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/whyrusleeping/ipld-schema/parser"
+)
+
+func TestSchemaSchema(t *testing.T) {
+	expected := loadExpected(t)
+	actual := loadActual(t)
+
+	for name, typ := range expected {
+		assert.Contains(t, actual, name)
+		assert.Equal(t, typ, actual[name], name)
+	}
+}
+
+func loadExpected(t *testing.T) map[string]interface{} {
+	var expected map[string]map[string]interface{}
+
+	file, err := ioutil.ReadFile("./fixtures/schema-schema.ipldsch.json")
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(file, &expected)
+	assert.NoError(t, err)
+
+	return expected["schema"]
+}
+
+func loadActual(t *testing.T) map[string]interface{} {
+	fi, err := os.Open("./fixtures/schema-schema.ipldsch")
+	assert.NoError(t, err)
+	defer fi.Close()
+	parsedSchema, err := parser.ParseSchema(bufio.NewScanner(fi))
+	assert.NoError(t, err)
+
+	jsonified, err := json.MarshalIndent(parsedSchema, "", "\t")
+	assert.NoError(t, err)
+
+	var actual map[string]interface{}
+	err = json.Unmarshal(jsonified, &actual)
+	assert.NoError(t, err)
+
+	return actual
+}


### PR DESCRIPTION
Sorry this is so large, I got deep into this once I started. The aim here was to bring this into closer alignment with current spec and to make it pass the test suite I'd been building at https://github.com/rvagg/js-ipld-schema — which I'd done using YAML & JSON to make it able to be portable when we had more than just a JS parser to test.

The majority of changes in here are done to get JSON marshalling working properly and matching spec. Some of that is awkward and involves replacing interfaces with concrete containers of subtypes (the representations do a lot of this), or the way `kind` is needed on everything, so it has to be supplied somewhere. parsing.go has most of the changes (note it'll be hidden by default by GitHub because the diff is large). schema.go will have some things that I'm sure will make you cringe but are there for JSONification.

Most of the testing involves JSONification, so it exercises that full path without caring about intermediate representation. The schema-schema test does JSON and back again to get matching `map[string]interface{}`s to compare.

I haven't done any tests yet for the to-schema path but I'd like to add that later to test that a schema parsed will go back the same way (it looks good atm, just eyeballing it). I also haven't touched anything in gen-go but it still compiles and runs at least.

If this doesn't match what you were planning on doing with this library then I'm find with doing something separate. Otherwise, perhaps we can work on getting this ready to go into github.com/ipld/ as the official Go parser? Either way, I've enjoyed this process and it's helped me think more Go-like and understand @warpfork's schema thinking a little more.