### PR TITLE
Formally support &Any &Foo link format and representations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ipld-schema

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -163,10 +163,10 @@ func (t *TypeEnum) TypeDecl() string {
 }
 
 func (t *TypeLink) TypeDecl() string {
-	if t.ValueType != nil {
-		return fmt.Sprintf("&%s", TypeTermDecl(t.ValueType))
+	if t.ExpectedType != nil {
+		return fmt.Sprintf("&%s", TypeTermDecl(t.ExpectedType))
 	}
-	return "link"
+	return "&Any"
 }
 
 func (t *TypeString) TypeDecl() string {
@@ -203,7 +203,7 @@ func SimpleType(kind string) Type {
 	case "int":
 		return &TypeInt{kind}
 	case "link":
-		return &TypeLink{kind, nil}
+		return &TypeLink{nil, kind}
 	case "string":
 		return &TypeString{kind}
 	}
@@ -276,8 +276,8 @@ type TypeFloat struct {
 }
 
 type TypeLink struct {
-	Kind      string   `json:"kind"`
-	ValueType TypeTerm `json:"valueType,omitempty"`
+	ExpectedType TypeTerm `json:"expectedType,omitempty"`
+	Kind         string   `json:"kind"`
 }
 
 type TypeList struct {
@@ -304,20 +304,20 @@ type UnionRepresentation struct {
 }
 
 type TypeName string
-type UnionRepresentation_Keyed map[string]TypeName
+type UnionRepresentation_Keyed map[string]Type
 
 type RepresentationKind string
-type UnionRepresentation_Kinded map[RepresentationKind]TypeName
+type UnionRepresentation_Kinded map[RepresentationKind]Type
 
 type UnionRepresentation_Envelope struct {
-	ContentKey        string              `json:"contentKey"`
-	DiscriminantKey   string              `json:"discriminantKey"`
-	DiscriminantTable map[string]TypeName `json:"discriminantTable"`
+	ContentKey        string          `json:"contentKey"`
+	DiscriminantKey   string          `json:"discriminantKey"`
+	DiscriminantTable map[string]Type `json:"discriminantTable"`
 }
 
 type UnionRepresentation_Inline struct {
-	DiscriminantKey   string              `json:"discriminantKey"`
-	DiscriminantTable map[string]TypeName `json:"discriminantTable"`
+	DiscriminantKey   string          `json:"discriminantKey"`
+	DiscriminantTable map[string]Type `json:"discriminantTable"`
 }
 
 type SchemaMap map[string]Type

--- a/test/fixtures/bulk/link-inline.yml
+++ b/test/fixtures/bulk/link-inline.yml
@@ -1,0 +1,40 @@
+schema: |
+  type Bar {String:&Baz}
+  type Baz struct {
+    boom String
+    foo &Foo
+  }
+  type Foo [Int]
+root: Foo
+expected: |
+  {
+    "Bar": {
+      "keyType": "String",
+      "kind": "map",
+      "valueType": {
+        "kind": "link",
+        "expectedType": "Baz"
+      }
+    },
+    "Baz": {
+      "fields": {
+        "boom": {
+          "type": "String"
+        },
+        "foo": {
+          "type": {
+            "kind": "link",
+            "expectedType": "Foo"
+          }
+        }
+      },
+      "kind": "struct",
+      "representation": {
+        "map": {}
+      }
+    },
+    "Foo": {
+      "kind": "list",
+      "valueType": "Int"
+    }
+  }

--- a/test/fixtures/bulk/link-kinded-union.yml
+++ b/test/fixtures/bulk/link-kinded-union.yml
@@ -1,0 +1,56 @@
+schema: |
+  type FileUnion union {
+    | File map
+    | &File link
+  } representation kinded
+  type File struct {
+    name optional String
+    data optional DataUnion
+  }
+  type DataUnion union {
+    | Data bytes
+    | &Data link
+  } representation kinded
+expected: |
+  {
+    "FileUnion": {
+      "kind": "union",
+      "representation": {
+        "kinded": {
+          "map": "File",
+          "link": {
+            "kind": "link",
+            "expectedType": "File"
+          }
+        }
+      }
+    },
+    "File": {
+      "kind": "struct",
+      "fields": {
+        "name": {
+          "type": "String",
+          "optional": true
+        },
+        "data": {
+          "type": "DataUnion",
+          "optional": true
+        }
+      },
+      "representation": {
+        "map": {}
+      }
+    },
+    "DataUnion": {
+      "kind": "union",
+      "representation": {
+        "kinded": {
+          "bytes": "Data",
+          "link": {
+            "kind": "link",
+            "expectedType": "Data"
+          }
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/link-typed.yml
+++ b/test/fixtures/bulk/link-typed.yml
@@ -1,0 +1,14 @@
+schema: |
+  type FooLink &Foo
+  type Foo bytes
+root: FooLink
+expected: |
+  {
+    "FooLink": {
+      "kind": "link",
+      "expectedType": "Foo"
+    },
+    "Foo": {
+      "kind": "bytes"
+    }
+  }

--- a/test/fixtures/bulk/link.yml
+++ b/test/fixtures/bulk/link.yml
@@ -1,5 +1,5 @@
 schema: |
-  type SimpleLink link
+  type SimpleLink &Any
 expected: |
   {
     "SimpleLink": {


### PR DESCRIPTION
Includes #1, so second commit (8aaf8cf currently) is the new one.

Pulls in the same test fixtures as https://github.com/ipld/js-ipld-schema/pull/8 to get parity

Ref: https://github.com/ipld/specs/pull/181
Ref: https://github.com/ipld/js-ipld-schema/pull/8