### PR TITLE
improvements for to-schema

### DIFF
--- a/gen-go/gen.go
+++ b/gen-go/gen.go
@@ -10,9 +10,9 @@ import (
 )
 
 // in reality, the 'right' way to do this is to probably use the golang ast packages
-func GolangCodeGen(sm SchemaMap, w io.Writer) error {
+func GolangCodeGen(schema *Schema, w io.Writer) error {
 	var types []string
-	for tname := range sm {
+	for tname := range schema.SchemaMap {
 		types = append(types, tname)
 	}
 
@@ -20,7 +20,7 @@ func GolangCodeGen(sm SchemaMap, w io.Writer) error {
 	fmt.Fprintf(w, "package main\n\n")
 
 	for _, tname := range types {
-		t := sm[tname]
+		t := schema.SchemaMap[tname]
 		tname := strings.Title(tname)
 		switch t := t.(type) {
 		case *TypeStruct:
@@ -71,7 +71,11 @@ func typeToGoType(t Type) string {
 		return "float64"
 
 	case *TypeLink:
-		return fmt.Sprintf("cid.Cid /* IPLD: %s */", typeToGoType(t))
+		et := "Any"
+		if t.ExpectedType != nil {
+			et = fmt.Sprintf("%s", t.ExpectedType)
+		}
+		return fmt.Sprintf("cid.Cid /* IPLD: %s */", et)
 
 	case *TypeList:
 		subtype := typeToGoType(t.ValueType.(Type)) // TypeTerm really wants to be a Type

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 	"github.com/urfave/cli"
 
 	gengo "github.com/whyrusleeping/ipld-schema/gen-go"
-	"github.com/whyrusleeping/ipld-schema/parser"
-	"github.com/whyrusleeping/ipld-schema/schema"
+	parser "github.com/whyrusleeping/ipld-schema/parser"
+	schema "github.com/whyrusleeping/ipld-schema/schema"
 )
 
 var genGoCmd = cli.Command{
@@ -27,12 +27,12 @@ var genGoCmd = cli.Command{
 		defer fi.Close()
 
 		s := bufio.NewScanner(fi)
-		sc, err := parser.ParseSchema(s)
+		sch, err := parser.ParseSchema(s)
 		if err != nil {
 			return err
 		}
 
-		if err := gengo.GolangCodeGen(sc, os.Stdout); err != nil {
+		if err := gengo.GolangCodeGen(sch, os.Stdout); err != nil {
 			return err
 		}
 
@@ -60,9 +60,7 @@ var schemaToJsonCmd = cli.Command{
 		}
 
 		// JSON schema types should be nested within a "schema" key
-		scm := make(map[string]interface{})
-		scm["schema"] = sc
-		out, err := json.MarshalIndent(scm, "", "\t")
+		out, err := json.MarshalIndent(sc, "", "\t")
 		if err != nil {
 			panic(err)
 		}
@@ -87,12 +85,12 @@ var schemaToSchemaCmd = cli.Command{
 		defer fi.Close()
 
 		s := bufio.NewScanner(fi)
-		sc, err := parser.ParseSchema(s)
+		sch, err := parser.ParseSchema(s)
 		if err != nil {
 			return err
 		}
 
-		if err := schema.ExportIpldSchema(sc, os.Stdout); err != nil {
+		if err := schema.ExportIpldSchema(sch, os.Stdout); err != nil {
 			panic(err)
 		}
 

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -229,6 +229,22 @@ func parseUnion(s *bufio.Scanner) (*TypeUnion, error) {
 				}
 
 				return &TypeUnion{Kind: "union", Representation: &UnionRepresentation{Envelope: urep}}, nil
+			case "byteprefix":
+				rep := make(UnionRepresentation_BytePrefix)
+				for k, v := range unionVals {
+					nt, ok := v.(NamedType)
+					if !ok {
+						return nil, fmt.Errorf("'byteprefix' union representation may only contain named types (%v)", v)
+					}
+					i, err := strconv.ParseInt(string(k), 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("'byteprefix' union representation may only use int discriminators (%v)", v)
+					}
+					rep[nt] = int(i)
+				}
+				return &TypeUnion{Kind: "union", Representation: &UnionRepresentation{BytePrefix: &rep}}, nil
+			default:
+				return nil, fmt.Errorf("unknown union representation '%s'", toks[2])
 			}
 
 		}

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -826,8 +826,9 @@ func parseStructRepr(line []string, s *bufio.Scanner, freps map[string]SRMFieldD
 	}
 }
 
-func ParseSchema(s *bufio.Scanner) (SchemaMap, error) {
-	sm := make(SchemaMap)
+func ParseSchema(s *bufio.Scanner) (*Schema, error) {
+	schema := &Schema{SchemaMap: make(SchemaMap)}
+
 	for s.Scan() {
 		toks := tokens(s.Text())
 		if len(toks) == 0 {
@@ -843,10 +844,10 @@ func ParseSchema(s *bufio.Scanner) (SchemaMap, error) {
 				fmt.Printf("%q\n", toks)
 				return nil, err
 			}
-			sm[name] = t
+			schema.SchemaMap[name] = t
 		default:
 			return nil, fmt.Errorf("unexpected token: %q", toks[0])
 		}
 	}
-	return sm, nil
+	return schema, nil
 }

--- a/schema/export.go
+++ b/schema/export.go
@@ -6,16 +6,16 @@ import (
 	"sort"
 )
 
-func ExportIpldSchema(sm SchemaMap, w io.Writer) error {
+func ExportIpldSchema(sch *Schema, w io.Writer) error {
 	var types []string
-	for tname := range sm {
+	for tname := range sch.SchemaMap {
 		types = append(types, tname)
 	}
 
 	sort.Strings(types)
 
 	for _, tname := range types {
-		t := sm[tname]
+		t := sch.SchemaMap[tname]
 		fmt.Fprintf(w, "type %s %s\n\n", tname, t.TypeDecl())
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -37,7 +37,7 @@ func (t *TypeStruct) TypeDecl() string {
 			}
 			if inf.Implicit != nil {
 				if inf.Rename != "" {
-					term += ", "
+					term += " "
 				}
 				var implicit interface{}
 				switch v := inf.Implicit.(type) {
@@ -63,12 +63,16 @@ func (t *TypeStruct) TypeDecl() string {
 		if t.Representation.Tuple != nil {
 			term += " representation tuple"
 			if t.Representation.Tuple.FieldOrder != nil {
-				term += fmt.Sprintf(" {\n\tfieldOrder [%s]\n}", strings.Join(t.Representation.Tuple.FieldOrder, ", "))
+				term += fmt.Sprintf(" {\n\tfieldOrder [\"%s\"]\n}", strings.Join(t.Representation.Tuple.FieldOrder, "\", \""))
 			}
 		} else if t.Representation.StringPairs != nil {
 			term += stringPairsRepresentationDecl(t.Representation.StringPairs)
 		} else if t.Representation.StringJoin != nil {
-			term += fmt.Sprintf(" representation stringjoin {\n\tjoin \"%s\"\n}", t.Representation.StringJoin.Join)
+			term += fmt.Sprintf(" representation stringjoin {\n\tjoin \"%s\"\n", t.Representation.StringJoin.Join)
+			if t.Representation.StringJoin.FieldOrder != nil {
+				term += fmt.Sprintf("\tfieldOrder [\"%s\"]\n", strings.Join(t.Representation.StringJoin.FieldOrder, "\", \""))
+			}
+			term += "}"
 		} else if t.Representation.ListPairs != nil {
 			term += " representation listpairs"
 		}
@@ -122,7 +126,7 @@ func (t *TypeUnion) TypeDecl() string {
 	if t.Representation != nil {
 		if t.Representation.Envelope != nil {
 			for k, v := range t.Representation.Envelope.DiscriminantTable {
-				term += fmt.Sprintf("\t| %s \"%s\"\n", v, k)
+				term += fmt.Sprintf("\t| %s \"%s\"\n", TypeTermDecl(v), k)
 			}
 			term += "} representation envelope {\n"
 			term += fmt.Sprintf("\tdiscriminantKey \"%s\"\n\tcontentKey \"%s\"\n}",
@@ -130,25 +134,25 @@ func (t *TypeUnion) TypeDecl() string {
 				t.Representation.Envelope.ContentKey)
 		} else if t.Representation.Keyed != nil {
 			for k, v := range *(t.Representation.Keyed) {
-				term += fmt.Sprintf("\t| %s \"%s\"\n", v, k)
+				term += fmt.Sprintf("\t| %s \"%s\"\n", TypeTermDecl(v), k)
 			}
 			term += "} representation keyed"
 		} else if t.Representation.Kinded != nil {
 			for k, v := range *(t.Representation.Kinded) {
-				term += fmt.Sprintf("\t| %s %s\n", v, k)
+				term += fmt.Sprintf("\t| %s %s\n", TypeTermDecl(v), k)
 			}
 
 			term += "} representation kinded"
 		} else if t.Representation.Inline != nil {
 			for k, v := range t.Representation.Inline.DiscriminantTable {
-				term += fmt.Sprintf("\t| %s %q\n", v, k)
+				term += fmt.Sprintf("\t| %s %q\n", TypeTermDecl(v), k)
 			}
 
 			term += fmt.Sprintf("} representation inline {\n\tdiscriminantKey \"%s\"\n}",
 				t.Representation.Inline.DiscriminantKey)
 		} else if t.Representation.BytePrefix != nil {
 			for k, v := range *(t.Representation.BytePrefix) {
-				term += fmt.Sprintf("\t| %s %d\n", k, v)
+				term += fmt.Sprintf("\t| %s %d\n", TypeTermDecl(k), v)
 			}
 
 			term += "} representation byteprefix"
@@ -327,6 +331,10 @@ type UnionRepresentation_BytePrefix map[NamedType]int
 type UnionRepresentation_Inline struct {
 	DiscriminantKey   string          `json:"discriminantKey"`
 	DiscriminantTable map[string]Type `json:"discriminantTable"`
+}
+
+type Schema struct {
+	SchemaMap SchemaMap `json:"schema"`
 }
 
 type SchemaMap map[string]Type

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -146,6 +146,12 @@ func (t *TypeUnion) TypeDecl() string {
 
 			term += fmt.Sprintf("} representation inline {\n\tdiscriminantKey \"%s\"\n}",
 				t.Representation.Inline.DiscriminantKey)
+		} else if t.Representation.BytePrefix != nil {
+			for k, v := range *(t.Representation.BytePrefix) {
+				term += fmt.Sprintf("\t| %s %d\n", k, v)
+			}
+
+			term += "} representation byteprefix"
 		} else {
 			panic(fmt.Sprintf("no representation type specified for union"))
 		}
@@ -297,10 +303,11 @@ type TypeUnion struct {
 }
 
 type UnionRepresentation struct {
-	Keyed    *UnionRepresentation_Keyed    `json:"keyed,omitempty"`
-	Kinded   *UnionRepresentation_Kinded   `json:"kinded,omitempty"`
-	Envelope *UnionRepresentation_Envelope `json:"envelope,omitempty"`
-	Inline   *UnionRepresentation_Inline   `json:"inline,omitempty"`
+	Keyed      *UnionRepresentation_Keyed      `json:"keyed,omitempty"`
+	Kinded     *UnionRepresentation_Kinded     `json:"kinded,omitempty"`
+	Envelope   *UnionRepresentation_Envelope   `json:"envelope,omitempty"`
+	Inline     *UnionRepresentation_Inline     `json:"inline,omitempty"`
+	BytePrefix *UnionRepresentation_BytePrefix `json:"byteprefix,omitempty"`
 }
 
 type TypeName string
@@ -314,6 +321,8 @@ type UnionRepresentation_Envelope struct {
 	DiscriminantKey   string          `json:"discriminantKey"`
 	DiscriminantTable map[string]Type `json:"discriminantTable"`
 }
+
+type UnionRepresentation_BytePrefix map[NamedType]int
 
 type UnionRepresentation_Inline struct {
 	DiscriminantKey   string          `json:"discriminantKey"`

--- a/test/bulk_fixtures_test.go
+++ b/test/bulk_fixtures_test.go
@@ -60,20 +60,18 @@ func verifyFixture(t *testing.T, name string) {
 		var out bytes.Buffer
 		err = schema.ExportIpldSchema(parsedSchema, &out)
 		assert.NoError(t, err)
-		regenerated := strings.Replace(strings.Replace(out.String(), "\t", "  ", -1), "\n\n", "\n", -1)
-	*/
-
-	/*
-		fmt.Println("--------- Original Schema:")
-		fmt.Printf(fx.Schema)
-		fmt.Println("--------- Regenerated Schema:")
-		fmt.Printf(regenerated)
+		regenerated := strings.ReplaceAll(out.String(), "\t", "  ")
+		regenerated = regenerated[0 : len(regenerated)-1]
 	*/
 
 	/* TODO: order of map[] fields in some structs causes shuffling so we can't do a straight compare
-			 without imposing order retention
+		without imposing order retention
+	fmt.Println("--------- Original Schema:")
+	fmt.Printf(fx.Schema)
+	fmt.Println("--------- Regenerated Schema:")
+	fmt.Printf(regenerated)
 
-	  assert.Equal(t, fx.Schema, regenerated)
+	assert.Equal(t, fx.Schema, regenerated)
 	*/
 }
 

--- a/test/fixtures/bulk/bytes.yml
+++ b/test/fixtures/bulk/bytes.yml
@@ -2,7 +2,9 @@ schema: |
   type SimpleBytes bytes
 expected: |
   {
-    "SimpleBytes": {
-      "kind": "bytes"
+    "schema": {
+      "SimpleBytes": {
+        "kind": "bytes"
+      }
     }
   }

--- a/test/fixtures/bulk/enum.yml
+++ b/test/fixtures/bulk/enum.yml
@@ -6,12 +6,14 @@ schema: |
   }
 expected: |
   {
-    "SimpleEnum": {
-      "kind": "enum",
-      "members": {
-        "foo": null,
-        "bar": null,
-        "baz": null
+    "schema": {
+      "SimpleEnum": {
+        "kind": "enum",
+        "members": {
+          "foo": null,
+          "bar": null,
+          "baz": null
+        }
       }
     }
   }

--- a/test/fixtures/bulk/float.yml
+++ b/test/fixtures/bulk/float.yml
@@ -2,8 +2,10 @@ schema: |
   type SimpleFloat float
 expected: |
   {
-    "SimpleFloat": {
-      "kind": "float"
+    "schema": {
+      "SimpleFloat": {
+        "kind": "float"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/int.yml
+++ b/test/fixtures/bulk/int.yml
@@ -2,8 +2,10 @@ schema: |
   type SimpleInt int
 expected: |
   {
-    "SimpleInt": {
-      "kind": "int"
+    "schema": {
+      "SimpleInt": {
+        "kind": "int"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/link-inline.yml
+++ b/test/fixtures/bulk/link-inline.yml
@@ -1,40 +1,44 @@
 schema: |
   type Bar {String:&Baz}
+
   type Baz struct {
     boom String
     foo &Foo
   }
+
   type Foo [Int]
 root: Foo
 expected: |
   {
-    "Bar": {
-      "keyType": "String",
-      "kind": "map",
-      "valueType": {
-        "kind": "link",
-        "expectedType": "Baz"
-      }
-    },
-    "Baz": {
-      "fields": {
-        "boom": {
-          "type": "String"
-        },
-        "foo": {
-          "type": {
-            "kind": "link",
-            "expectedType": "Foo"
-          }
+    "schema": {
+      "Bar": {
+        "keyType": "String",
+        "kind": "map",
+        "valueType": {
+          "kind": "link",
+          "expectedType": "Baz"
         }
       },
-      "kind": "struct",
-      "representation": {
-        "map": {}
+      "Baz": {
+        "fields": {
+          "boom": {
+            "type": "String"
+          },
+          "foo": {
+            "type": {
+              "kind": "link",
+              "expectedType": "Foo"
+            }
+          }
+        },
+        "kind": "struct",
+        "representation": {
+          "map": {}
+        }
+      },
+      "Foo": {
+        "kind": "list",
+        "valueType": "Int"
       }
-    },
-    "Foo": {
-      "kind": "list",
-      "valueType": "Int"
     }
   }

--- a/test/fixtures/bulk/link-kinded-union.yml
+++ b/test/fixtures/bulk/link-kinded-union.yml
@@ -3,52 +3,56 @@ schema: |
     | File map
     | &File link
   } representation kinded
+
   type File struct {
     name optional String
     data optional DataUnion
   }
+
   type DataUnion union {
     | Data bytes
     | &Data link
   } representation kinded
 expected: |
   {
-    "FileUnion": {
-      "kind": "union",
-      "representation": {
-        "kinded": {
-          "map": "File",
-          "link": {
-            "kind": "link",
-            "expectedType": "File"
+    "schema": {
+      "FileUnion": {
+        "kind": "union",
+        "representation": {
+          "kinded": {
+            "map": "File",
+            "link": {
+              "kind": "link",
+              "expectedType": "File"
+            }
           }
         }
-      }
-    },
-    "File": {
-      "kind": "struct",
-      "fields": {
-        "name": {
-          "type": "String",
-          "optional": true
+      },
+      "File": {
+        "kind": "struct",
+        "fields": {
+          "name": {
+            "type": "String",
+            "optional": true
+          },
+          "data": {
+            "type": "DataUnion",
+            "optional": true
+          }
         },
-        "data": {
-          "type": "DataUnion",
-          "optional": true
+        "representation": {
+          "map": {}
         }
       },
-      "representation": {
-        "map": {}
-      }
-    },
-    "DataUnion": {
-      "kind": "union",
-      "representation": {
-        "kinded": {
-          "bytes": "Data",
-          "link": {
-            "kind": "link",
-            "expectedType": "Data"
+      "DataUnion": {
+        "kind": "union",
+        "representation": {
+          "kinded": {
+            "bytes": "Data",
+            "link": {
+              "kind": "link",
+              "expectedType": "Data"
+            }
           }
         }
       }

--- a/test/fixtures/bulk/link-typed.yml
+++ b/test/fixtures/bulk/link-typed.yml
@@ -1,14 +1,17 @@
 schema: |
   type FooLink &Foo
+
   type Foo bytes
 root: FooLink
 expected: |
   {
-    "FooLink": {
-      "kind": "link",
-      "expectedType": "Foo"
-    },
-    "Foo": {
-      "kind": "bytes"
+    "schema": {
+      "FooLink": {
+        "kind": "link",
+        "expectedType": "Foo"
+      },
+      "Foo": {
+        "kind": "bytes"
+      }
     }
   }

--- a/test/fixtures/bulk/link.yml
+++ b/test/fixtures/bulk/link.yml
@@ -2,7 +2,9 @@ schema: |
   type SimpleLink &Any
 expected: |
   {
-    "SimpleLink": {
-      "kind": "link"
+    "schema": {
+      "SimpleLink": {
+        "kind": "link"
+      }
     }
   }

--- a/test/fixtures/bulk/list.yml
+++ b/test/fixtures/bulk/list.yml
@@ -2,9 +2,11 @@ schema: |
   type SimpleList [String]
 expected: |
   {
-    "SimpleList": {
-      "kind": "list",
-      "valueType": "String"
+    "schema": {
+      "SimpleList": {
+        "kind": "list",
+        "valueType": "String"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/map-listpairs.yml
+++ b/test/fixtures/bulk/map-listpairs.yml
@@ -2,10 +2,12 @@ schema: |
   type MapAsListpairs {String:String} representation listpairs
 expected: |
   {
-    "MapAsListpairs": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "String",
-      "representation": { "listpairs": {} }
+    "schema": {
+      "MapAsListpairs": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "String",
+        "representation": { "listpairs": {} }
+      }
     }
   }

--- a/test/fixtures/bulk/map-stringpairs.yml
+++ b/test/fixtures/bulk/map-stringpairs.yml
@@ -5,14 +5,16 @@ schema: |
   }
 expected: |
   {
-    "MapAsStringpairs": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "String",
-      "representation": {
-        "stringpairs": {
-          "innerDelim": "=",
-          "entryDelim": ","
+    "schema": {
+      "MapAsStringpairs": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "String",
+        "representation": {
+          "stringpairs": {
+            "innerDelim": "=",
+            "entryDelim": ","
+          }
         }
       }
     }

--- a/test/fixtures/bulk/map-with-nullable.yml
+++ b/test/fixtures/bulk/map-with-nullable.yml
@@ -2,10 +2,12 @@ schema: |
   type MapWithNullable {String:nullable String}
 expected: |
   {
-    "MapWithNullable": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "String",
-      "valueNullable": true
+    "schema": {
+      "MapWithNullable": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "String",
+        "valueNullable": true
+      }
     }
   }

--- a/test/fixtures/bulk/map.yml
+++ b/test/fixtures/bulk/map.yml
@@ -2,10 +2,12 @@ schema: |
   type SimpleMap {String:Int}
 expected: |
   {
-    "SimpleMap": {
-      "kind": "map",
-      "keyType": "String",
-      "valueType": "Int"
+    "schema": {
+      "SimpleMap": {
+        "kind": "map",
+        "keyType": "String",
+        "valueType": "Int"
+      }
     }
   }
 blocks:

--- a/test/fixtures/bulk/struct-empty.yml
+++ b/test/fixtures/bulk/struct-empty.yml
@@ -1,0 +1,20 @@
+schema: |
+  type StructEmpty struct { }
+  type StructEmptyTight struct {}
+expected: |
+  {
+    "StructEmpty": {
+      "kind": "struct",
+      "fields": {},
+      "representation": {
+        "map": {}
+      }
+    },
+    "StructEmptyTight": {
+      "kind": "struct",
+      "fields": {},
+      "representation": {
+        "map": {}
+      }
+    }
+  }

--- a/test/fixtures/bulk/struct-empty.yml
+++ b/test/fixtures/bulk/struct-empty.yml
@@ -1,20 +1,27 @@
 schema: |
   type StructEmpty struct { }
+
+  type StructEmptyTight struct {}
+canonical: |
+  type StructEmpty struct {}
+
   type StructEmptyTight struct {}
 expected: |
   {
-    "StructEmpty": {
-      "kind": "struct",
-      "fields": {},
-      "representation": {
-        "map": {}
-      }
-    },
-    "StructEmptyTight": {
-      "kind": "struct",
-      "fields": {},
-      "representation": {
-        "map": {}
+    "schema": {
+      "StructEmpty": {
+        "kind": "struct",
+        "fields": {},
+        "representation": {
+          "map": {}
+        }
+      },
+      "StructEmptyTight": {
+        "kind": "struct",
+        "fields": {},
+        "representation": {
+          "map": {}
+        }
       }
     }
   }

--- a/test/fixtures/bulk/struct-listpairs.yml
+++ b/test/fixtures/bulk/struct-listpairs.yml
@@ -6,19 +6,22 @@ schema: |
   } representation listpairs
 expected: |
   {
-    "StructAsListpairs": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsListpairs": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": { "listpairs": {} }
+        "representation": { "listpairs": {} }
+      }
     }
   }
+

--- a/test/fixtures/bulk/struct-map-with-implicits.yml
+++ b/test/fixtures/bulk/struct-map-with-implicits.yml
@@ -7,28 +7,30 @@ schema: |
   }
 expected: |
   {
-    "StructAsMapWithImplicits": {
-      "kind": "struct",
-      "fields": {
-        "bar": {
-          "type": "Bool"
+    "schema": {
+      "StructAsMapWithImplicits": {
+        "kind": "struct",
+        "fields": {
+          "bar": {
+            "type": "Bool"
+          },
+          "boom": {
+            "type": "String"
+          },
+          "baz": {
+            "type": "String"
+          },
+          "foo": {
+            "type": "Int"
+          }
         },
-        "boom": {
-          "type": "String"
-        },
-        "baz": {
-          "type": "String"
-        },
-        "foo": {
-          "type": "Int"
-        }
-      },
-      "representation": {
-        "map": {
-          "fields": {
-            "bar": { "implicit": false },
-            "boom": { "implicit": "yay" },
-            "foo": { "implicit": 0 }
+        "representation": {
+          "map": {
+            "fields": {
+              "bar": { "implicit": false },
+              "boom": { "implicit": "yay" },
+              "foo": { "implicit": 0 }
+            }
           }
         }
       }

--- a/test/fixtures/bulk/struct-map-with-renames.yml
+++ b/test/fixtures/bulk/struct-map-with-renames.yml
@@ -3,34 +3,36 @@ schema: |
     bar Bool (rename "b")
     boom String
     baz String (rename "z")
-    foo Int (implicit "0" rename "f")
+    foo Int (rename "f" implicit "0")
   }
 expected: |
   {
-    "StructAsMapWithRenames": {
-      "kind": "struct",
-      "fields": {
-        "bar": {
-          "type": "Bool"
+    "schema": {
+      "StructAsMapWithRenames": {
+        "kind": "struct",
+        "fields": {
+          "bar": {
+            "type": "Bool"
+          },
+          "boom": {
+            "type": "String"
+          },
+          "baz": {
+            "type": "String"
+          },
+          "foo": {
+            "type": "Int"
+          }
         },
-        "boom": {
-          "type": "String"
-        },
-        "baz": {
-          "type": "String"
-        },
-        "foo": {
-          "type": "Int"
-        }
-      },
-      "representation": {
-        "map": {
-          "fields": {
-            "bar": { "rename": "b" },
-            "baz": { "rename": "z" },
-            "foo": {
-              "implicit": 0,
-              "rename": "f"
+        "representation": {
+          "map": {
+            "fields": {
+              "bar": { "rename": "b" },
+              "baz": { "rename": "z" },
+              "foo": {
+                "implicit": 0,
+                "rename": "f"
+              }
             }
           }
         }

--- a/test/fixtures/bulk/struct-stringjoin-custom-fieldorder.yml
+++ b/test/fixtures/bulk/struct-stringjoin-custom-fieldorder.yml
@@ -9,27 +9,29 @@ schema: |
   }
 expected: |
   {
-    "StructAsStringjoin": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsStringjoin": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": {
-        "stringjoin": {
-          "fieldOrder": [
-            "baz",
-            "bar",
-            "foo"
-          ],
-          "join": ":"
+        "representation": {
+          "stringjoin": {
+            "fieldOrder": [
+              "baz",
+              "bar",
+              "foo"
+            ],
+            "join": ":"
+          }
         }
       }
     }

--- a/test/fixtures/bulk/struct-stringjoin.yml
+++ b/test/fixtures/bulk/struct-stringjoin.yml
@@ -8,21 +8,23 @@ schema: |
   }
 expected: |
   {
-    "StructAsStringjoin": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsStringjoin": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
+        "representation": {
+          "stringjoin": { "join": ":" }
         }
-      },
-      "representation": {
-        "stringjoin": { "join": ":" }
       }
     }
   }

--- a/test/fixtures/bulk/struct-stringpairs.yml
+++ b/test/fixtures/bulk/struct-stringpairs.yml
@@ -9,23 +9,25 @@ schema: |
   }
 expected: |
   {
-    "StructAsStringpairs": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsStringpairs": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": {
-        "stringpairs": {
-          "innerDelim": "=",
-          "entryDelim": ","
+        "representation": {
+          "stringpairs": {
+            "innerDelim": "=",
+            "entryDelim": ","
+          }
         }
       }
     }

--- a/test/fixtures/bulk/struct-tuple-custom-fieldorder.yml
+++ b/test/fixtures/bulk/struct-tuple-custom-fieldorder.yml
@@ -8,26 +8,28 @@ schema: |
   }
 expected: |
   {
-    "StructAsTupleWithCustomFieldorder": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructAsTupleWithCustomFieldorder": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
-        }
-      },
-      "representation": {
-        "tuple": {
-          "fieldOrder": [
-            "baz",
-            "bar",
-            "foo"
-          ]
+        "representation": {
+          "tuple": {
+            "fieldOrder": [
+              "baz",
+              "bar",
+              "foo"
+            ]
+          }
         }
       }
     }

--- a/test/fixtures/bulk/struct-tuple.yml
+++ b/test/fixtures/bulk/struct-tuple.yml
@@ -1,4 +1,3 @@
-
 schema: |
   type StructTuple struct {
     foo Int
@@ -7,21 +6,23 @@ schema: |
   } representation tuple
 expected: |
   {
-    "StructTuple": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "StructTuple": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
+        "representation": {
+          "tuple": {}
         }
-      },
-      "representation": {
-        "tuple": {}
       }
     }
   }

--- a/test/fixtures/bulk/struct-with-anonymous-types.yml
+++ b/test/fixtures/bulk/struct-with-anonymous-types.yml
@@ -7,47 +7,50 @@ schema: |
   }
 expected: |
   {
-    "StructWithAnonymousTypes": {
-      "kind": "struct",
-      "fields": {
-        "fooField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": "String"
+    "schema": {
+      "StructWithAnonymousTypes": {
+        "kind": "struct",
+        "fields": {
+          "fooField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
+              "valueType": "String"
+            },
+            "optional": true
           },
-          "optional": true
-        },
-        "barField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": "String"
+          "barField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
+              "valueType": "String"
+            },
+            "nullable": true
           },
-          "nullable": true
-        },
-        "bazField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": "String",
-            "valueNullable": true
-          }
-        },
-        "wozField": {
-          "type": {
-            "kind": "map",
-            "keyType": "String",
-            "valueType": {
-              "kind": "list",
+          "bazField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
               "valueType": "String",
               "valueNullable": true
             }
+          },
+          "wozField": {
+            "type": {
+              "kind": "map",
+              "keyType": "String",
+              "valueType": {
+                "kind": "list",
+                "valueType": "String",
+                "valueNullable": true
+              }
+            }
           }
+        },
+        "representation": {
+          "map": {}
         }
-      },
-      "representation": {
-        "map": {}
       }
     }
   }
+

--- a/test/fixtures/bulk/struct.yml
+++ b/test/fixtures/bulk/struct.yml
@@ -6,21 +6,23 @@ schema: |
   }
 expected: |
   {
-    "SimpleStruct": {
-      "kind": "struct",
-      "fields": {
-        "foo": {
-          "type": "Int"
+    "schema": {
+      "SimpleStruct": {
+        "kind": "struct",
+        "fields": {
+          "foo": {
+            "type": "Int"
+          },
+          "bar": {
+            "type": "Bool"
+          },
+          "baz": {
+            "type": "String"
+          }
         },
-        "bar": {
-          "type": "Bool"
-        },
-        "baz": {
-          "type": "String"
+        "representation": {
+          "map": {}
         }
-      },
-      "representation": {
-        "map": {}
       }
     }
   }

--- a/test/fixtures/bulk/union-byteprefix.yml
+++ b/test/fixtures/bulk/union-byteprefix.yml
@@ -1,6 +1,8 @@
 schema: |
   type Bls12_381Signature bytes
+
   type Secp256k1Signature bytes
+
   type Signature union {
     | Secp256k1Signature 0
     | Bls12_381Signature 1
@@ -8,18 +10,20 @@ schema: |
 root: Signature
 expected: |
   {
-    "Bls12_381Signature": {
-      "kind": "bytes"
-    },
-    "Secp256k1Signature": {
-      "kind": "bytes"
-    },
-    "Signature": {
-      "kind": "union",
-      "representation": {
-        "byteprefix": {
-          "Secp256k1Signature": 0,
-          "Bls12_381Signature": 1
+    "schema": {
+      "Bls12_381Signature": {
+        "kind": "bytes"
+      },
+      "Secp256k1Signature": {
+        "kind": "bytes"
+      },
+      "Signature": {
+        "kind": "union",
+        "representation": {
+          "byteprefix": {
+            "Secp256k1Signature": 0,
+            "Bls12_381Signature": 1
+          }
         }
       }
     }

--- a/test/fixtures/bulk/union-byteprefix.yml
+++ b/test/fixtures/bulk/union-byteprefix.yml
@@ -1,0 +1,26 @@
+schema: |
+  type Bls12_381Signature bytes
+  type Secp256k1Signature bytes
+  type Signature union {
+    | Secp256k1Signature 0
+    | Bls12_381Signature 1
+  } representation byteprefix
+root: Signature
+expected: |
+  {
+    "Bls12_381Signature": {
+      "kind": "bytes"
+    },
+    "Secp256k1Signature": {
+      "kind": "bytes"
+    },
+    "Signature": {
+      "kind": "union",
+      "representation": {
+        "byteprefix": {
+          "Secp256k1Signature": 0,
+          "Bls12_381Signature": 1
+        }
+      }
+    }
+  }

--- a/test/fixtures/bulk/union-envelope.yml
+++ b/test/fixtures/bulk/union-envelope.yml
@@ -1,7 +1,10 @@
 schema: |
   type Bar bool
+
   type Baz string
+
   type Foo int
+
   type UnionEnvelope union {
     | Foo "foo"
     | Bar "bar"
@@ -13,25 +16,27 @@ schema: |
 root: UnionEnvelope
 expected: |
   {
-    "Bar": {
-      "kind": "bool"
-    },
-    "Baz": {
-      "kind": "string"
-    },
-    "Foo": {
-      "kind": "int"
-    },
-    "UnionEnvelope": {
-      "kind": "union",
-      "representation": {
-        "envelope": {
-          "discriminantKey": "bim",
-          "contentKey": "bam",
-          "discriminantTable": {
-            "foo": "Foo",
-            "bar": "Bar",
-            "baz": "Baz"
+    "schema": {
+      "Bar": {
+        "kind": "bool"
+      },
+      "Baz": {
+        "kind": "string"
+      },
+      "Foo": {
+        "kind": "int"
+      },
+      "UnionEnvelope": {
+        "kind": "union",
+        "representation": {
+          "envelope": {
+            "discriminantKey": "bim",
+            "contentKey": "bam",
+            "discriminantTable": {
+              "foo": "Foo",
+              "bar": "Bar",
+              "baz": "Baz"
+            }
           }
         }
       }

--- a/test/fixtures/bulk/union-inline.yml
+++ b/test/fixtures/bulk/union-inline.yml
@@ -2,9 +2,11 @@ schema: |
   type Bar struct {
     bral String
   }
+
   type Foo struct {
     froz Bool
   }
+
   type UnionInline union {
     | Foo "foo"
     | Bar "bar"
@@ -14,38 +16,40 @@ schema: |
 root: UnionInline
 expected: |
   {
-    "UnionInline": {
-      "kind": "union",
-      "representation": {
-        "inline": {
-          "discriminantKey": "tag",
-          "discriminantTable": {
-            "foo": "Foo",
-            "bar": "Bar"
+    "schema": {
+      "UnionInline": {
+        "kind": "union",
+        "representation": {
+          "inline": {
+            "discriminantKey": "tag",
+            "discriminantTable": {
+              "foo": "Foo",
+              "bar": "Bar"
+            }
           }
         }
-      }
-    },
-    "Foo": {
-      "kind": "struct",
-      "fields": {
-        "froz": {
-          "type": "Bool"
+      },
+      "Foo": {
+        "kind": "struct",
+        "fields": {
+          "froz": {
+            "type": "Bool"
+          }
+        },
+        "representation": {
+          "map": {}
         }
       },
-      "representation": {
-        "map": {}
-      }
-    },
-    "Bar": {
-      "kind": "struct",
-      "fields": {
-        "bral": {
-          "type": "String"
+      "Bar": {
+        "kind": "struct",
+        "fields": {
+          "bral": {
+            "type": "String"
+          }
+        },
+        "representation": {
+          "map": {}
         }
-      },
-      "representation": {
-        "map": {}
       }
     }
   }

--- a/test/fixtures/bulk/union-keyed.yml
+++ b/test/fixtures/bulk/union-keyed.yml
@@ -6,13 +6,15 @@ schema: |
   } representation keyed
 expected: |
   {
-    "UnionKeyed": {
-      "kind": "union",
-      "representation": {
-        "keyed": {
-          "bar": "Bool",
-          "foo": "Int",
-          "baz": "String"
+    "schema": {
+      "UnionKeyed": {
+        "kind": "union",
+        "representation": {
+          "keyed": {
+            "bar": "Bool",
+            "foo": "Int",
+            "baz": "String"
+          }
         }
       }
     }

--- a/test/fixtures/bulk/union-kinded.yml
+++ b/test/fixtures/bulk/union-kinded.yml
@@ -1,7 +1,10 @@
 schema: |
   type Bar bool
+
   type Baz string
+
   type Foo int
+
   type UnionKinded union {
     | Foo int
     | Bar bool
@@ -10,22 +13,24 @@ schema: |
 root: UnionKinded
 expected: |
   {
-    "Bar": {
-      "kind": "bool"
-    },
-    "Baz": {
-      "kind": "string"
-    },
-    "Foo": {
-      "kind": "int"
-    },
-    "UnionKinded": {
-      "kind": "union",
-      "representation": {
-        "kinded": {
-          "int": "Foo",
-          "bool": "Bar",
-          "string": "Baz"
+    "schema": {
+      "Bar": {
+        "kind": "bool"
+      },
+      "Baz": {
+        "kind": "string"
+      },
+      "Foo": {
+        "kind": "int"
+      },
+      "UnionKinded": {
+        "kind": "union",
+        "representation": {
+          "kinded": {
+            "int": "Foo",
+            "bool": "Bar",
+            "string": "Baz"
+          }
         }
       }
     }

--- a/test/schema_schema_test.go
+++ b/test/schema_schema_test.go
@@ -22,7 +22,7 @@ func TestSchemaSchema(t *testing.T) {
 }
 
 func loadExpected(t *testing.T) map[string]interface{} {
-	var expected map[string]map[string]interface{}
+	var expected map[string]interface{}
 
 	file, err := ioutil.ReadFile("./fixtures/schema-schema.ipldsch.json")
 	assert.NoError(t, err)
@@ -30,7 +30,7 @@ func loadExpected(t *testing.T) map[string]interface{} {
 	err = json.Unmarshal(file, &expected)
 	assert.NoError(t, err)
 
-	return expected["schema"]
+	return expected
 }
 
 func loadActual(t *testing.T) map[string]interface{} {


### PR DESCRIPTION
Coming out of some work in https://github.com/ipld/js-ipld-schema/pull/15, changes aren't too big and I tried again to get `to-schema` tests working but Go's map ordering keeps on getting in the way. We're going to have to move to arrays for many of these internal structures and do custom JSONification so we can retain input order for `to-json` and `to-schema`.